### PR TITLE
As Well: homepage sections + product templates

### DIFF
--- a/sections/aswell-announcements.liquid
+++ b/sections/aswell-announcements.liquid
@@ -1,0 +1,52 @@
+{% if section.settings.enabled %}
+<section class="section section--{{ section.settings.background }}" style="padding-top:{{ section.settings.padding_top }}px;padding-bottom:{{ section.settings.padding_bottom }}px;">
+  <div class="page-width announcement-wrapper">
+    {% for block in section.blocks %}
+      <div class="announcement-bar" {{ block.shopify_attributes }}>
+        <p>{{ block.settings.text }}</p>
+        <button type="button" class="announcement-bar__close" aria-label="Dismiss">&times;</button>
+      </div>
+    {% endfor %}
+  </div>
+</section>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.announcement-bar__close').forEach(function(btn){
+      btn.addEventListener('click', function(){ btn.parentElement.style.display = 'none'; });
+    });
+  });
+</script>
+{% endif %}
+
+{% schema %}
+{
+  "name": "As Well announcements",
+  "settings": [
+    { "type": "checkbox", "id": "enabled", "label": "Enable section", "default": true },
+    { "type": "range", "id": "padding_top", "label": "Top spacing", "min":0, "max":100, "step":4, "default":0, "unit":"px" },
+    { "type": "range", "id": "padding_bottom", "label": "Bottom spacing", "min":0, "max":100, "step":4, "default":0, "unit":"px" },
+    { "type": "select", "id": "background", "label": "Background", "default": "light", "options": [
+      { "value": "light", "label": "Light" },
+      { "value": "neutral", "label": "Neutral" }
+    ]}
+  ],
+  "blocks": [
+    {
+      "type": "announcement",
+      "name": "Announcement",
+      "settings": [
+        { "type": "text", "id": "text", "label": "Text" }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "As Well announcements",
+      "blocks": [
+        { "type": "announcement", "settings": { "text": "Complimentary standard shipping on UK orders over £50." } },
+        { "type": "announcement", "settings": { "text": "Enjoy a free 10-serve sample with orders over £100—while stocks last." } }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/aswell-benefits.liquid
+++ b/sections/aswell-benefits.liquid
@@ -1,0 +1,55 @@
+{% if section.settings.enabled %}
+<section class="section section--{{ section.settings.background }}" style="padding-top:{{ section.settings.padding_top }}px;padding-bottom:{{ section.settings.padding_bottom }}px;">
+  <div class="page-width">
+    {% if section.settings.section_title != blank %}<h2>{{ section.settings.section_title }}</h2>{% endif %}
+    <div class="grid grid--3-col">
+      {% for block in section.blocks %}
+        <div class="benefit" {{ block.shopify_attributes }}>
+          {% if block.settings.icon != blank %}<img src="{{ block.settings.icon | default: 'https://via.placeholder.com/64x64' }}" alt="{{ block.settings.title }}">{% endif %}
+          {% if block.settings.title != blank %}<h3>{{ block.settings.title }}</h3>{% endif %}
+          {% if block.settings.copy != blank %}<p>{{ block.settings.copy }}</p>{% endif %}
+        </div>
+      {% endfor %}
+    </div>
+    {% if section.settings.disclaimer != blank %}<p class="disclaimer">{{ section.settings.disclaimer }}</p>{% endif %}
+  </div>
+</section>
+{% endif %}
+
+{% schema %}
+{
+  "name": "As Well benefits",
+  "settings": [
+    { "type": "checkbox", "id": "enabled", "label": "Enable section", "default": true },
+    { "type": "text", "id": "section_title", "label": "Title", "default": "Designed for daily support" },
+    { "type": "text", "id": "disclaimer", "label": "Disclaimer", "default": "As Well products are food supplements. They are not intended to diagnose, treat, cure, or prevent any disease. Consult your healthcare professional if using prescription medication." },
+    { "type": "range", "id": "padding_top", "label": "Top spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "range", "id": "padding_bottom", "label": "Bottom spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "select", "id": "background", "label": "Background", "default": "light", "options": [
+      { "value": "light", "label": "Light" },
+      { "value": "neutral", "label": "Neutral" }
+    ]}
+  ],
+  "blocks": [
+    {
+      "type": "benefit",
+      "name": "Benefit",
+      "settings": [
+        { "type": "image_picker", "id": "icon", "label": "Icon" },
+        { "type": "text", "id": "title", "label": "Title" },
+        { "type": "text", "id": "copy", "label": "Copy" }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "As Well benefits",
+      "blocks": [
+        { "type": "benefit", "settings": { "title": "GLP-1 Support", "copy": "Fibre diversity and key minerals to complement fullness pathways.*", "icon": "https://via.placeholder.com/64x64" } },
+        { "type": "benefit", "settings": { "title": "Hydration", "copy": "Sodium-balanced electrolytes to help water where it counts.", "icon": "https://via.placeholder.com/64x64" } },
+        { "type": "benefit", "settings": { "title": "Appetite Control", "copy": "Premium fibres for gentle satiety without heaviness.", "icon": "https://via.placeholder.com/64x64" } }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/aswell-category-grid.liquid
+++ b/sections/aswell-category-grid.liquid
@@ -1,0 +1,55 @@
+{% if section.settings.enabled %}
+<section class="section section--{{ section.settings.background }}" style="padding-top:{{ section.settings.padding_top }}px;padding-bottom:{{ section.settings.padding_bottom }}px;">
+  <div class="page-width">
+    {% if section.settings.section_title != blank %}<h2>{{ section.settings.section_title }}</h2>{% endif %}
+    {% if section.settings.section_copy != blank %}<p>{{ section.settings.section_copy }}</p>{% endif %}
+    <div class="grid grid--3-col">
+      {% for block in section.blocks %}
+        <div class="category-grid__item" {{ block.shopify_attributes }}>
+          <a href="{{ block.settings.url }}">{{ block.settings.title }}</a>
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+{% endif %}
+
+{% schema %}
+{
+  "name": "As Well category grid",
+  "settings": [
+    { "type": "checkbox", "id": "enabled", "label": "Enable section", "default": true },
+    { "type": "text", "id": "section_title", "label": "Title", "default": "Discover by category" },
+    { "type": "text", "id": "section_copy", "label": "Copy", "default": "Browse by intention and let the rest be simple." },
+    { "type": "range", "id": "padding_top", "label": "Top spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "range", "id": "padding_bottom", "label": "Bottom spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "select", "id": "background", "label": "Background", "default": "light", "options": [
+      { "value": "light", "label": "Light" },
+      { "value": "neutral", "label": "Neutral" }
+    ]}
+  ],
+  "blocks": [
+    {
+      "type": "link",
+      "name": "Link",
+      "settings": [
+        { "type": "text", "id": "title", "label": "Title" },
+        { "type": "url", "id": "url", "label": "Link" }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "As Well category grid",
+      "blocks": [
+        { "type": "link", "settings": { "title": "Hydration & Electrolytes", "url": "/collections/hydration" } },
+        { "type": "link", "settings": { "title": "Appetite & Satiety", "url": "/collections/appetite" } },
+        { "type": "link", "settings": { "title": "Energy & Focus", "url": "/collections/energy" } },
+        { "type": "link", "settings": { "title": "Gut & Regularity", "url": "/collections/gut" } },
+        { "type": "link", "settings": { "title": "Keto-Friendly", "url": "/collections/keto" } },
+        { "type": "link", "settings": { "title": "Bundles", "url": "/collections/bundles" } }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/aswell-editorial-block.liquid
+++ b/sections/aswell-editorial-block.liquid
@@ -1,0 +1,35 @@
+{% if section.settings.enabled %}
+<section class="section section--{{ section.settings.background }}" style="padding-top:{{ section.settings.padding_top }}px;padding-bottom:{{ section.settings.padding_bottom }}px;">
+  <div class="page-width">
+    {% if section.settings.eyebrow != blank %}<p class="eyebrow">{{ section.settings.eyebrow }}</p>{% endif %}
+    {% if section.settings.title != blank %}<h2>{{ section.settings.title }}</h2>{% endif %}
+    {% if section.settings.body != blank %}<div class="rte">{{ section.settings.body }}</div>{% endif %}
+    {% if section.settings.cta_label != blank and section.settings.cta_url != blank %}
+      <a href="{{ section.settings.cta_url }}" class="button">{{ section.settings.cta_label }}</a>
+    {% endif %}
+  </div>
+</section>
+{% endif %}
+
+{% schema %}
+{
+  "name": "As Well editorial block",
+  "settings": [
+    { "type": "checkbox", "id": "enabled", "label": "Enable section", "default": true },
+    { "type": "text", "id": "eyebrow", "label": "Eyebrow", "default": "The As Well approach" },
+    { "type": "text", "id": "title", "label": "Title", "default": "Fewer products, better rituals" },
+    { "type": "richtext", "id": "body", "label": "Body", "default": "<p>We design essentials that disappear into your day—quiet formulas, transparent labels, no noise. Considered fibres, supportive electrolytes, and actives with a reason to be there. Nothing more.</p>" },
+    { "type": "text", "id": "cta_label", "label": "CTA label", "default": "Read our standards →" },
+    { "type": "url", "id": "cta_url", "label": "CTA link", "default": "/pages/standards" },
+    { "type": "range", "id": "padding_top", "label": "Top spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "range", "id": "padding_bottom", "label": "Bottom spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "select", "id": "background", "label": "Background", "default": "light", "options": [
+      { "value": "light", "label": "Light" },
+      { "value": "neutral", "label": "Neutral" }
+    ]}
+  ],
+  "presets": [
+    { "name": "As Well editorial block" }
+  ]
+}
+{% endschema %}

--- a/sections/aswell-hero.liquid
+++ b/sections/aswell-hero.liquid
@@ -1,0 +1,49 @@
+{% if section.settings.enabled %}
+<section class="section section--{{ section.settings.background }}" style="padding-top:{{ section.settings.padding_top }}px;padding-bottom:{{ section.settings.padding_bottom }}px;">
+  <div class="page-width">
+    <div class="aswell-hero grid grid--2-col">
+      <div class="aswell-hero__text">
+        {% if section.settings.eyebrow != blank %}
+          <p class="eyebrow">{{ section.settings.eyebrow }}</p>
+        {% endif %}
+        <h1>{{ section.settings.title }}</h1>
+        {% if section.settings.body != blank %}
+          <div class="rte">{{ section.settings.body }}</div>
+        {% endif %}
+        {% if section.settings.cta_label != blank and section.settings.cta_url != blank %}
+          <a href="{{ section.settings.cta_url }}" class="button">{{ section.settings.cta_label }}</a>
+        {% endif %}
+      </div>
+      <div class="aswell-hero__media">
+        <picture>
+          <source media="(min-width: 750px)" srcset="{{ section.settings.image_desktop | default: 'https://via.placeholder.com/1600x900' }}">
+          <img src="{{ section.settings.image_mobile | default: 'https://via.placeholder.com/800x800' }}" alt="">
+        </picture>
+      </div>
+    </div>
+  </div>
+</section>
+{% endif %}
+
+{% schema %}
+{
+  "name": "As Well hero",
+  "settings": [
+    { "type": "checkbox", "id": "enabled", "label": "Enable section", "default": true },
+    { "type": "text", "id": "eyebrow", "label": "Eyebrow", "default": "Everyday nourishment, elegantly done" },
+    { "type": "text", "id": "title", "label": "Title", "default": "Feel lighter. Live As Well." },
+    { "type": "richtext", "id": "body", "label": "Body", "default": "<p>Our quiet daily rituals—dissolving Sprinkle blends and Wake Gummies—pair premium fibres with electrolytes, probiotics and thoughtful actives. Keto-friendly, sugar-free and crafted to support hydration, appetite control and a steadier day.</p>" },
+    { "type": "image_picker", "id": "image_desktop", "label": "Desktop image" },
+    { "type": "image_picker", "id": "image_mobile", "label": "Mobile image" },
+    { "type": "text", "id": "cta_label", "label": "CTA label", "default": "Shop the collection" },
+    { "type": "url", "id": "cta_url", "label": "CTA link", "default": "/collections/all" },
+    { "type": "range", "id": "padding_top", "label": "Top spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "range", "id": "padding_bottom", "label": "Bottom spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "select", "id": "background", "label": "Background", "default": "light", "options": [
+      { "value": "light", "label": "Light" },
+      { "value": "neutral", "label": "Neutral" }
+    ]}
+  ],
+  "presets": [{ "name": "As Well hero" }]
+}
+{% endschema %}

--- a/sections/aswell-how-it-works.liquid
+++ b/sections/aswell-how-it-works.liquid
@@ -1,0 +1,59 @@
+{% if section.settings.enabled %}
+<section class="section section--{{ section.settings.background }}" style="padding-top:{{ section.settings.padding_top }}px;padding-bottom:{{ section.settings.padding_bottom }}px;">
+  <div class="page-width">
+    <div class="grid grid--2-col">
+      <div>
+        {% if section.settings.eyebrow != blank %}<p class="eyebrow">{{ section.settings.eyebrow }}</p>{% endif %}
+        <h2>{{ section.settings.title }}</h2>
+      </div>
+      <div>
+        {% if section.settings.copy != blank %}<div class="rte">{{ section.settings.copy }}</div>{% endif %}
+        {% if section.settings.microcopy != blank %}<p class="microcopy">{{ section.settings.microcopy }}</p>{% endif %}
+        {% if section.settings.show_icons %}
+          <div class="icon-row">
+            {% for block in section.blocks %}
+              <div class="icon-row__item" {{ block.shopify_attributes }}>
+                {% if block.settings.icon != blank %}<img src="{{ block.settings.icon | default: 'https://via.placeholder.com/64x64' }}" alt="{{ block.settings.label }}">{% endif %}
+                {% if block.settings.label != blank %}<p>{{ block.settings.label }}</p>{% endif %}
+              </div>
+            {% endfor %}
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</section>
+{% endif %}
+
+{% schema %}
+{
+  "name": "As Well how it works",
+  "settings": [
+    { "type": "checkbox", "id": "enabled", "label": "Enable section", "default": true },
+    { "type": "text", "id": "eyebrow", "label": "Eyebrow", "default": "The simple ritual" },
+    { "type": "text", "id": "title", "label": "Title", "default": "Sprinkle • Stir • Savour" },
+    { "type": "richtext", "id": "copy", "label": "Copy", "default": "<p>Our blends dissolve instantly in drinks and sprinkle seamlessly on food. The texture disappears; flavour stays true. Use once or twice daily—breakfast porridge, a smoothie, an iced coffee, or your evening yoghurt.</p>" },
+    { "type": "text", "id": "microcopy", "label": "Microcopy", "default": "Free from sugars and artificial sweeteners. Keto-friendly." },
+    { "type": "checkbox", "id": "show_icons", "label": "Show icon row", "default": false },
+    { "type": "range", "id": "padding_top", "label": "Top spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "range", "id": "padding_bottom", "label": "Bottom spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "select", "id": "background", "label": "Background", "default": "light", "options": [
+      { "value": "light", "label": "Light" },
+      { "value": "neutral", "label": "Neutral" }
+    ]}
+  ],
+  "blocks": [
+    {
+      "type": "icon",
+      "name": "Icon",
+      "settings": [
+        { "type": "image_picker", "id": "icon", "label": "Icon" },
+        { "type": "text", "id": "label", "label": "Label" }
+      ]
+    }
+  ],
+  "presets": [
+    { "name": "As Well how it works" }
+  ]
+}
+{% endschema %}

--- a/sections/aswell-ingredient-spotlight.liquid
+++ b/sections/aswell-ingredient-spotlight.liquid
@@ -1,0 +1,54 @@
+{% if section.settings.enabled %}
+<section class="section section--{{ section.settings.background }}" style="padding-top:{{ section.settings.padding_top }}px;padding-bottom:{{ section.settings.padding_bottom }}px;">
+  <div class="page-width">
+    {% if section.settings.eyebrow != blank %}<p class="eyebrow">{{ section.settings.eyebrow }}</p>{% endif %}
+    {% for block in section.blocks %}
+      <div class="grid grid--2-col ingredient-spotlight__row" {{ block.shopify_attributes }}>
+        <div>
+          {% if block.settings.title != blank %}<h3>{{ block.settings.title }}</h3>{% endif %}
+          {% if block.settings.copy != blank %}<div class="rte">{{ block.settings.copy }}</div>{% endif %}
+        </div>
+        {% if block.settings.image != blank %}
+          <div><img src="{{ block.settings.image | default: 'https://via.placeholder.com/800x800' }}" alt="{{ block.settings.title }}"></div>
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
+</section>
+{% endif %}
+
+{% schema %}
+{
+  "name": "As Well ingredient spotlight",
+  "settings": [
+    { "type": "checkbox", "id": "enabled", "label": "Enable section", "default": true },
+    { "type": "text", "id": "eyebrow", "label": "Eyebrow", "default": "Hero ingredients" },
+    { "type": "range", "id": "padding_top", "label": "Top spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "range", "id": "padding_bottom", "label": "Bottom spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "select", "id": "background", "label": "Background", "default": "light", "options": [
+      { "value": "light", "label": "Light" },
+      { "value": "neutral", "label": "Neutral" }
+    ]}
+  ],
+  "blocks": [
+    {
+      "type": "item",
+      "name": "Item",
+      "settings": [
+        { "type": "text", "id": "title", "label": "Title" },
+        { "type": "richtext", "id": "copy", "label": "Copy" },
+        { "type": "image_picker", "id": "image", "label": "Image" }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "As Well ingredient spotlight",
+      "blocks": [
+        { "type": "item", "settings": { "title": "Chromium • the quiet stabiliser", "copy": "<p>Included as chromium picolinate, this trace mineral supports normal macronutrient metabolism and helps maintain normal blood glucose levels—useful alongside high-fibre satiety.*</p>", "image": "https://via.placeholder.com/800x800" } },
+        { "type": "item", "settings": { "title": "Green Coffee • clean lift, calm edge", "copy": "<p>Naturally occurring polyphenols with a gentle caffeine profile. In our Sprinkle Blend it remains taste-neutral; in Wake Gummies it brings focus without the spike.*</p>", "image": "https://via.placeholder.com/800x800" } }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/aswell-newsletter.liquid
+++ b/sections/aswell-newsletter.liquid
@@ -1,0 +1,35 @@
+{% if section.settings.enabled %}
+<section class="section section--{{ section.settings.background }}" style="padding-top:{{ section.settings.padding_top }}px;padding-bottom:{{ section.settings.padding_bottom }}px;">
+  <div class="page-width">
+    {% if section.settings.title != blank %}<h2>{{ section.settings.title }}</h2>{% endif %}
+    {% if section.settings.copy != blank %}<p>{{ section.settings.copy }}</p>{% endif %}
+    {% form 'customer', class: 'newsletter-form' %}
+      <input type="hidden" name="contact[tags]" value="newsletter">
+      <input type="email" name="contact[email]" placeholder="{{ section.settings.placeholder }}" required>
+      <button type="submit" class="button">{{ section.settings.button_label }}</button>
+    {% endform %}
+  </div>
+</section>
+{% endif %}
+
+{% schema %}
+{
+  "name": "As Well newsletter",
+  "settings": [
+    { "type": "checkbox", "id": "enabled", "label": "Enable section", "default": true },
+    { "type": "text", "id": "title", "label": "Title", "default": "Join the ritual" },
+    { "type": "text", "id": "copy", "label": "Copy", "default": "Early access to drops, behind-the-label notes, and simple how-tos." },
+    { "type": "text", "id": "placeholder", "label": "Placeholder", "default": "Your email" },
+    { "type": "text", "id": "button_label", "label": "Button label", "default": "Subscribe" },
+    { "type": "range", "id": "padding_top", "label": "Top spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "range", "id": "padding_bottom", "label": "Bottom spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "select", "id": "background", "label": "Background", "default": "light", "options": [
+      { "value": "light", "label": "Light" },
+      { "value": "neutral", "label": "Neutral" }
+    ]}
+  ],
+  "presets": [
+    { "name": "As Well newsletter" }
+  ]
+}
+{% endschema %}

--- a/sections/aswell-product-tiles.liquid
+++ b/sections/aswell-product-tiles.liquid
@@ -1,0 +1,108 @@
+{% if section.settings.enabled %}
+<section class="section section--{{ section.settings.background }}" style="padding-top:{{ section.settings.padding_top }}px;padding-bottom:{{ section.settings.padding_bottom }}px;">
+  <div class="page-width">
+    <div class="grid grid--3-col">
+      {% for block in section.blocks %}
+        <div class="product-tile" {{ block.shopify_attributes }}>
+          {% if block.settings.image != blank %}
+            <img src="{{ block.settings.image | default: 'https://via.placeholder.com/600x600' }}" alt="{{ block.settings.title }}">
+          {% endif %}
+          {% if block.settings.title != blank %}<h3>{{ block.settings.title }}</h3>{% endif %}
+          {% if block.settings.subline != blank %}<p>{{ block.settings.subline }}</p>{% endif %}
+          <ul>
+            {% if block.settings.bullet_1 != blank %}<li>{{ block.settings.bullet_1 }}</li>{% endif %}
+            {% if block.settings.bullet_2 != blank %}<li>{{ block.settings.bullet_2 }}</li>{% endif %}
+            {% if block.settings.bullet_3 != blank %}<li>{{ block.settings.bullet_3 }}</li>{% endif %}
+          </ul>
+          {% if block.settings.footnote != blank %}<small>{{ block.settings.footnote }}</small>{% endif %}
+          {% if block.settings.cta_label != blank and block.settings.cta_url != blank %}
+            <a href="{{ block.settings.cta_url }}" class="button">{{ block.settings.cta_label }}</a>
+          {% endif %}
+        </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+{% endif %}
+
+{% schema %}
+{
+  "name": "As Well product tiles",
+  "settings": [
+    { "type": "checkbox", "id": "enabled", "label": "Enable section", "default": true },
+    { "type": "range", "id": "padding_top", "label": "Top spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "range", "id": "padding_bottom", "label": "Bottom spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "select", "id": "background", "label": "Background", "default": "light", "options": [
+      { "value": "light", "label": "Light" },
+      { "value": "neutral", "label": "Neutral" }
+    ]}
+  ],
+  "blocks": [
+    {
+      "type": "tile",
+      "name": "Tile",
+      "limit": 3,
+      "settings": [
+        { "type": "image_picker", "id": "image", "label": "Image" },
+        { "type": "text", "id": "title", "label": "Title" },
+        { "type": "text", "id": "subline", "label": "Subline" },
+        { "type": "text", "id": "bullet_1", "label": "Bullet 1" },
+        { "type": "text", "id": "bullet_2", "label": "Bullet 2" },
+        { "type": "text", "id": "bullet_3", "label": "Bullet 3" },
+        { "type": "text", "id": "footnote", "label": "Footnote" },
+        { "type": "text", "id": "cta_label", "label": "CTA label", "default": "Shop now" },
+        { "type": "url", "id": "cta_url", "label": "CTA link" }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "As Well product tiles",
+      "blocks": [
+        {
+          "type": "tile",
+          "settings": {
+            "title": "As Well Sprinkle Blend",
+            "subline": "6+ Premium Fibres • Electrolytes • Probiotics",
+            "bullet_1": "GLP-1 Support",
+            "bullet_2": "Hydration",
+            "bullet_3": "Appetite Control",
+            "footnote": "With Chromium & Green Coffee. Vegan • Non-GMO • Sugar-free",
+            "cta_label": "Shop Sprinkle Blend →",
+            "cta_url": "/products/sprinkle-am",
+            "image": "https://via.placeholder.com/600x600"
+          }
+        },
+        {
+          "type": "tile",
+          "settings": {
+            "title": "As Well Sprinkle Blend – Evening",
+            "subline": "Same gentle base, a calmer finish",
+            "bullet_1": "GLP-1 Support",
+            "bullet_2": "Hydration",
+            "bullet_3": "Appetite Control",
+            "footnote": "With Magnesium & Chamomile extract. Vegan • Non-GMO • Sugar-free",
+            "cta_label": "Shop Sprinkle Blend →",
+            "cta_url": "/products/sprinkle-pm",
+            "image": "https://via.placeholder.com/600x600"
+          }
+        },
+        {
+          "type": "tile",
+          "settings": {
+            "title": "As Well Wake Gummies",
+            "subline": "Clean lift, no jitters",
+            "bullet_1": "B-vitamins",
+            "bullet_2": "L-Theanine",
+            "bullet_3": "Natural caffeine (green coffee)",
+            "footnote": "Vegan • Non-GMO • Sugar-free",
+            "cta_label": "Shop Wake Gummies →",
+            "cta_url": "/products/wake-gummies",
+            "image": "https://via.placeholder.com/600x600"
+          }
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/aswell-quote-strip.liquid
+++ b/sections/aswell-quote-strip.liquid
@@ -1,0 +1,30 @@
+{% if section.settings.enabled %}
+<section class="section section--{{ section.settings.background }}" style="padding-top:{{ section.settings.padding_top }}px;padding-bottom:{{ section.settings.padding_bottom }}px;">
+  <div class="page-width">
+    <blockquote class="quote-strip">
+      <p>{{ section.settings.quote }}</p>
+      {% if section.settings.author != blank %}<cite>{{ section.settings.author }}</cite>{% endif %}
+    </blockquote>
+  </div>
+</section>
+{% endif %}
+
+{% schema %}
+{
+  "name": "As Well quote strip",
+  "settings": [
+    { "type": "checkbox", "id": "enabled", "label": "Enable section", "default": true },
+    { "type": "text", "id": "quote", "label": "Quote", "default": "Consistency makes progress feel effortless." },
+    { "type": "text", "id": "author", "label": "Author", "default": "As Well" },
+    { "type": "range", "id": "padding_top", "label": "Top spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "range", "id": "padding_bottom", "label": "Bottom spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "select", "id": "background", "label": "Background", "default": "light", "options": [
+      { "value": "light", "label": "Light" },
+      { "value": "neutral", "label": "Neutral" }
+    ]}
+  ],
+  "presets": [
+    { "name": "As Well quote strip" }
+  ]
+}
+{% endschema %}

--- a/sections/aswell-testimonials.liquid
+++ b/sections/aswell-testimonials.liquid
@@ -1,0 +1,47 @@
+{% if section.settings.enabled %}
+<section class="section section--{{ section.settings.background }}" style="padding-top:{{ section.settings.padding_top }}px;padding-bottom:{{ section.settings.padding_bottom }}px;">
+  <div class="page-width">
+    <div class="testimonials">
+      {% for block in section.blocks %}
+        <blockquote class="testimonial" {{ block.shopify_attributes }}>
+          <p>{{ block.settings.quote }}</p>
+        </blockquote>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+{% endif %}
+
+{% schema %}
+{
+  "name": "As Well testimonials",
+  "settings": [
+    { "type": "checkbox", "id": "enabled", "label": "Enable section", "default": true },
+    { "type": "range", "id": "padding_top", "label": "Top spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "range", "id": "padding_bottom", "label": "Bottom spacing", "min":0, "max":100, "step":4, "default":36, "unit":"px" },
+    { "type": "select", "id": "background", "label": "Background", "default": "light", "options": [
+      { "value": "light", "label": "Light" },
+      { "value": "neutral", "label": "Neutral" }
+    ]}
+  ],
+  "blocks": [
+    {
+      "type": "quote",
+      "name": "Quote",
+      "settings": [
+        { "type": "text", "id": "quote", "label": "Quote" }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "As Well testimonials",
+      "blocks": [
+        { "type": "quote", "settings": { "quote": "My morning coffee, but balanced." } },
+        { "type": "quote", "settings": { "quote": "Fuller for longer—without the chalky shakes." } },
+        { "type": "quote", "settings": { "quote": "Evenings are calmer; late-night snacking is down." } }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/templates/index.json
+++ b/templates/index.json
@@ -1,0 +1,219 @@
+{
+  "sections": {
+    "aswell-announcements": {
+      "type": "aswell-announcements",
+      "settings": {
+        "enabled": true,
+        "padding_top": 0,
+        "padding_bottom": 0,
+        "background": "light"
+      },
+      "blocks": {
+        "announcement-1": {
+          "type": "announcement",
+          "settings": {
+            "text": "Complimentary standard shipping on UK orders over £50."
+          }
+        },
+        "announcement-2": {
+          "type": "announcement",
+          "settings": {
+            "text": "Enjoy a free 10-serve sample with orders over £100—while stocks last."
+          }
+        }
+      },
+      "block_order": ["announcement-1", "announcement-2"]
+    },
+    "aswell-hero": {
+      "type": "aswell-hero",
+      "settings": {
+        "enabled": true,
+        "eyebrow": "Everyday nourishment, elegantly done",
+        "title": "Feel lighter. Live As Well.",
+        "body": "<p>Our quiet daily rituals—dissolving Sprinkle blends and Wake Gummies—pair premium fibres with electrolytes, probiotics and thoughtful actives. Keto-friendly, sugar-free and crafted to support hydration, appetite control and a steadier day.</p>",
+        "image_desktop": "https://via.placeholder.com/1600x900",
+        "image_mobile": "https://via.placeholder.com/800x800",
+        "cta_label": "Shop the collection",
+        "cta_url": "/collections/all",
+        "padding_top": 36,
+        "padding_bottom": 36,
+        "background": "light"
+      }
+    },
+    "aswell-product-tiles": {
+      "type": "aswell-product-tiles",
+      "settings": {
+        "enabled": true,
+        "padding_top": 36,
+        "padding_bottom": 36,
+        "background": "light"
+      },
+      "blocks": {
+        "tile-1": {
+          "type": "tile",
+          "settings": {
+            "title": "As Well Sprinkle Blend",
+            "subline": "6+ Premium Fibres • Electrolytes • Probiotics",
+            "bullet_1": "GLP-1 Support",
+            "bullet_2": "Hydration",
+            "bullet_3": "Appetite Control",
+            "footnote": "With Chromium & Green Coffee. Vegan • Non-GMO • Sugar-free",
+            "cta_label": "Shop Sprinkle Blend →",
+            "cta_url": "/products/sprinkle-am",
+            "image": "https://via.placeholder.com/600x600"
+          }
+        },
+        "tile-2": {
+          "type": "tile",
+          "settings": {
+            "title": "As Well Sprinkle Blend – Evening",
+            "subline": "Same gentle base, a calmer finish",
+            "bullet_1": "GLP-1 Support",
+            "bullet_2": "Hydration",
+            "bullet_3": "Appetite Control",
+            "footnote": "With Magnesium & Chamomile extract. Vegan • Non-GMO • Sugar-free",
+            "cta_label": "Shop Sprinkle Blend →",
+            "cta_url": "/products/sprinkle-pm",
+            "image": "https://via.placeholder.com/600x600"
+          }
+        },
+        "tile-3": {
+          "type": "tile",
+          "settings": {
+            "title": "As Well Wake Gummies",
+            "subline": "Clean lift, no jitters",
+            "bullet_1": "B-vitamins",
+            "bullet_2": "L-Theanine",
+            "bullet_3": "Natural caffeine (green coffee)",
+            "footnote": "Vegan • Non-GMO • Sugar-free",
+            "cta_label": "Shop Wake Gummies →",
+            "cta_url": "/products/wake-gummies",
+            "image": "https://via.placeholder.com/600x600"
+          }
+        }
+      },
+      "block_order": ["tile-1", "tile-2", "tile-3"]
+    },
+    "aswell-category-grid": {
+      "type": "aswell-category-grid",
+      "settings": {
+        "enabled": true,
+        "section_title": "Discover by category",
+        "section_copy": "Browse by intention and let the rest be simple.",
+        "padding_top": 36,
+        "padding_bottom": 36,
+        "background": "light"
+      },
+      "blocks": {
+        "link-1": { "type": "link", "settings": { "title": "Hydration & Electrolytes", "url": "/collections/hydration" } },
+        "link-2": { "type": "link", "settings": { "title": "Appetite & Satiety", "url": "/collections/appetite" } },
+        "link-3": { "type": "link", "settings": { "title": "Energy & Focus", "url": "/collections/energy" } },
+        "link-4": { "type": "link", "settings": { "title": "Gut & Regularity", "url": "/collections/gut" } },
+        "link-5": { "type": "link", "settings": { "title": "Keto-Friendly", "url": "/collections/keto" } },
+        "link-6": { "type": "link", "settings": { "title": "Bundles", "url": "/collections/bundles" } }
+      },
+      "block_order": ["link-1", "link-2", "link-3", "link-4", "link-5", "link-6"]
+    },
+    "aswell-how-it-works": {
+      "type": "aswell-how-it-works",
+      "settings": {
+        "enabled": true,
+        "eyebrow": "The simple ritual",
+        "title": "Sprinkle • Stir • Savour",
+        "copy": "<p>Our blends dissolve instantly in drinks and sprinkle seamlessly on food. The texture disappears; flavour stays true. Use once or twice daily—breakfast porridge, a smoothie, an iced coffee, or your evening yoghurt.</p>",
+        "microcopy": "Free from sugars and artificial sweeteners. Keto-friendly.",
+        "show_icons": false,
+        "padding_top": 36,
+        "padding_bottom": 36,
+        "background": "light"
+      }
+    },
+    "aswell-benefits": {
+      "type": "aswell-benefits",
+      "settings": {
+        "enabled": true,
+        "section_title": "Designed for daily support",
+        "disclaimer": "As Well products are food supplements. They are not intended to diagnose, treat, cure, or prevent any disease. Consult your healthcare professional if using prescription medication.",
+        "padding_top": 36,
+        "padding_bottom": 36,
+        "background": "light"
+      },
+      "blocks": {
+        "benefit-1": { "type": "benefit", "settings": { "title": "GLP-1 Support", "copy": "Fibre diversity and key minerals to complement fullness pathways.*", "icon": "https://via.placeholder.com/64x64" } },
+        "benefit-2": { "type": "benefit", "settings": { "title": "Hydration", "copy": "Sodium-balanced electrolytes to help water where it counts.", "icon": "https://via.placeholder.com/64x64" } },
+        "benefit-3": { "type": "benefit", "settings": { "title": "Appetite Control", "copy": "Premium fibres for gentle satiety without heaviness.", "icon": "https://via.placeholder.com/64x64" } }
+      },
+      "block_order": ["benefit-1", "benefit-2", "benefit-3"]
+    },
+    "aswell-ingredient-spotlight": {
+      "type": "aswell-ingredient-spotlight",
+      "settings": {
+        "enabled": true,
+        "eyebrow": "Hero ingredients",
+        "padding_top": 36,
+        "padding_bottom": 36,
+        "background": "light"
+      },
+      "blocks": {
+        "item-1": { "type": "item", "settings": { "title": "Chromium • the quiet stabiliser", "copy": "<p>Included as chromium picolinate, this trace mineral supports normal macronutrient metabolism and helps maintain normal blood glucose levels—useful alongside high-fibre satiety.*</p>", "image": "https://via.placeholder.com/800x800" } },
+        "item-2": { "type": "item", "settings": { "title": "Green Coffee • clean lift, calm edge", "copy": "<p>Naturally occurring polyphenols with a gentle caffeine profile. In our Sprinkle Blend it remains taste-neutral; in Wake Gummies it brings focus without the spike.*</p>", "image": "https://via.placeholder.com/800x800" } }
+      },
+      "block_order": ["item-1", "item-2"]
+    },
+    "aswell-testimonials": {
+      "type": "aswell-testimonials",
+      "settings": {
+        "enabled": true,
+        "padding_top": 36,
+        "padding_bottom": 36,
+        "background": "light"
+      },
+      "blocks": {
+        "quote-1": { "type": "quote", "settings": { "quote": "My morning coffee, but balanced." } },
+        "quote-2": { "type": "quote", "settings": { "quote": "Fuller for longer—without the chalky shakes." } },
+        "quote-3": { "type": "quote", "settings": { "quote": "Evenings are calmer; late-night snacking is down." } }
+      },
+      "block_order": ["quote-1", "quote-2", "quote-3"],
+      "disabled": true
+    },
+    "aswell-editorial-block": {
+      "type": "aswell-editorial-block",
+      "settings": {
+        "enabled": true,
+        "eyebrow": "The As Well approach",
+        "title": "Fewer products, better rituals",
+        "body": "<p>We design essentials that disappear into your day—quiet formulas, transparent labels, no noise. Considered fibres, supportive electrolytes, and actives with a reason to be there. Nothing more.</p>",
+        "cta_label": "Read our standards →",
+        "cta_url": "/pages/standards",
+        "padding_top": 36,
+        "padding_bottom": 36,
+        "background": "light"
+      }
+    },
+    "aswell-quote-strip": {
+      "type": "aswell-quote-strip",
+      "settings": {
+        "enabled": true,
+        "quote": "Consistency makes progress feel effortless.",
+        "author": "As Well",
+        "padding_top": 36,
+        "padding_bottom": 36,
+        "background": "light"
+      }
+    },
+    "aswell-newsletter": {
+      "type": "aswell-newsletter",
+      "settings": {
+        "enabled": true,
+        "title": "Join the ritual",
+        "copy": "Early access to drops, behind-the-label notes, and simple how-tos.",
+        "placeholder": "Your email",
+        "button_label": "Subscribe",
+        "padding_top": 36,
+        "padding_bottom": 36,
+        "background": "light"
+      }
+    }
+  },
+  "order": ["aswell-announcements", "aswell-hero", "aswell-product-tiles", "aswell-category-grid", "aswell-how-it-works", "aswell-benefits", "aswell-ingredient-spotlight", "aswell-testimonials", "aswell-editorial-block", "aswell-quote-strip", "aswell-newsletter"]
+}

--- a/templates/product.sprinkle-am.json
+++ b/templates/product.sprinkle-am.json
@@ -1,0 +1,18 @@
+{
+  "sections": {
+    "main": {
+      "type": "main-product",
+      "settings": {},
+      "blocks": {
+        "title": { "type": "title", "settings": {} },
+        "price": { "type": "price", "settings": {} },
+        "variant_picker": { "type": "variant_picker", "settings": {} },
+        "buy_buttons": { "type": "buy_buttons", "settings": {} },
+        "description": { "type": "description", "settings": {} },
+        "how_to_use": { "type": "text", "settings": { "text": "Sprinkle one scoop into any drink or onto food; stir and enjoy. Once daily to start; increase to twice daily if desired. Tastes neutral." } }
+      },
+      "block_order": ["title", "price", "variant_picker", "buy_buttons", "description", "how_to_use"]
+    }
+  },
+  "order": ["main"]
+}

--- a/templates/product.sprinkle-pm.json
+++ b/templates/product.sprinkle-pm.json
@@ -1,0 +1,18 @@
+{
+  "sections": {
+    "main": {
+      "type": "main-product",
+      "settings": {},
+      "blocks": {
+        "title": { "type": "title", "settings": {} },
+        "price": { "type": "price", "settings": {} },
+        "variant_picker": { "type": "variant_picker", "settings": {} },
+        "buy_buttons": { "type": "buy_buttons", "settings": {} },
+        "description": { "type": "description", "settings": {} },
+        "how_to_use": { "type": "text", "settings": { "text": "As above, with a calmer finish (Magnesium & Chamomile)." } }
+      },
+      "block_order": ["title", "price", "variant_picker", "buy_buttons", "description", "how_to_use"]
+    }
+  },
+  "order": ["main"]
+}

--- a/templates/product.wake-gummies.json
+++ b/templates/product.wake-gummies.json
@@ -1,0 +1,18 @@
+{
+  "sections": {
+    "main": {
+      "type": "main-product",
+      "settings": {},
+      "blocks": {
+        "title": { "type": "title", "settings": {} },
+        "price": { "type": "price", "settings": {} },
+        "variant_picker": { "type": "variant_picker", "settings": {} },
+        "buy_buttons": { "type": "buy_buttons", "settings": {} },
+        "description": { "type": "description", "settings": {} },
+        "how_to_use": { "type": "text", "settings": { "text": "1–2 gummies when needed. Avoid within 6 hours of sleep." } }
+      },
+      "block_order": ["title", "price", "variant_picker", "buy_buttons", "description", "how_to_use"]
+    }
+  },
+  "order": ["main"]
+}


### PR DESCRIPTION
## Summary
- add As Well homepage sections with defaults
- wire new sections into `templates/index.json`
- add product templates for Sprinkle AM/PM and Wake Gummies

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab115f6e808320bd721a9d1c9bdbf2